### PR TITLE
chore: use SPDX identifier Apache-2.0 in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = ""
 authors = [
     {name = "C. Allwardt",email = "3979063+craig8@users.noreply.github.com"}
 ]
-license = {text = "Apache 2.0"}
+license = "Apache-2.0"
 readme = "README.md"
 requires-python = ">=3.10,<4.0"
 


### PR DESCRIPTION
Normalize the license field in `pyproject.toml` to the SPDX identifier `Apache-2.0`.